### PR TITLE
chore(ci): fix docker push by adding provenance false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ linux: export GOARCH=amd64
 linux: build
 
 docker: linux
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build --provenance=false -t $(IMAGE):$(VERSION) .
 
 push:
 	docker push $(IMAGE):$(VERSION)


### PR DESCRIPTION
## Description

This update disables provenance in the Docker build to ensure compatibility with our internal registry by adding the `--provenance=false` flag to the build command.
